### PR TITLE
Add button to relevant docs page from feature pages

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -44,7 +44,7 @@ layout: default
         {% endif %}
         {{ content }}
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
-        {% if page.docs %}<div id="docs-button"><a href="{{ page.docs }}" class="btn btn--primary btn--docs">Link to documentation page</a></div>{% endif %}
+        {% if page.docs %}<div id="docs-button"><a href="{{ page.docs }}" class="btn btn--info">Link to documentation page</a></div>{% endif %}
       </section>
 
       <footer class="page__meta">

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -44,6 +44,7 @@ layout: default
         {% endif %}
         {{ content }}
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
+        {% if page.docs %}<div id="docs-button"><a href="{{ page.docs }}" class="btn btn--primary btn--docs">Link to documentation page</a></div>{% endif %}
       </section>
 
       <footer class="page__meta">

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -44,7 +44,7 @@ layout: default
         {% endif %}
         {{ content }}
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
-        {% if page.docs %}<div id="docs-button"><a href="{{ page.docs }}" class="btn btn--info">Link to documentation page</a></div>{% endif %}
+        {% if page.docs %}<div id="docs-button"><a href="{{ page.docs }}" class="btn btn--info" role="button">Link to documentation page</a></div>{% endif %}
       </section>
 
       <footer class="page__meta">

--- a/_pages/api_and_programmatic_access.md
+++ b/_pages/api_and_programmatic_access.md
@@ -2,6 +2,7 @@
 permalink: /api_and_programmatic_access.html
 title: "API and Programmatic Access"
 layout: single
+docs: https://docs.seek4science.org/help/user-guide/api
 ---
 
 FAIRDOM-SEEK includes a [JSON](https://www.json.org/) Application Programming Interface (API) that allows the searching, listing, reading, updating and creating of many items in your FAIRDOM-SEEK instance, along with their attributes.

--- a/_pages/explore.md
+++ b/_pages/explore.md
@@ -3,6 +3,7 @@ permalink: /explore.html
 title: "Explore spreadsheets"
 layout: single
 redirect_from: '/explore_and_annotate.html'
+docs: https://docs.seek4science.org/help/user-guide/adding-assets
 ---
 
 Excel spreadsheets can be explored without the need to download.

--- a/_pages/extended_metadata.md
+++ b/_pages/extended_metadata.md
@@ -2,6 +2,7 @@
 permalink: /extended_metadata.html
 title: "Extended Metadata"
 layout: single
+docs: https://docs.seek4science.org/tech/extended-metadata/extended-metadata-type
 ---
 
 Extended Metadata is a feature added to FAIRDOM-SEEK as part of version 1.11, originally to support plant phenotyping [(MIAPPE)](https://github.com/MIAPPE/MIAPPE).

--- a/_pages/flexible_sharing.md
+++ b/_pages/flexible_sharing.md
@@ -2,6 +2,7 @@
 permalink: /flexible_sharing.html
 title: "Flexible sharing controls"
 layout: single
+docs: https://docs.seek4science.org/help/user-guide/general-attributes#sharing
 ---
 
 There is a lot of flexibility and control over who can see, download or edit your items.

--- a/_pages/organise.md
+++ b/_pages/organise.md
@@ -2,6 +2,7 @@
 permalink: /organise.html
 title: "Organise and store you data"
 layout: single
+docs: https://docs.seek4science.org/help/user-guide/isa-overview
 ---
 
 FAIRDOM-SEEK has adopted an ISATAB style structure for organising experiments and data.

--- a/_pages/publishing_and_doi.md
+++ b/_pages/publishing_and_doi.md
@@ -2,6 +2,7 @@
 permalink: /publishing_and_doi.html
 title: "Publishing and DOI"
 layout: single
+docs: https://docs.seek4science.org/tech/administration#configuring-doi-and-pubmed-search
 ---
 
 If research resulted in a publication, this can also be registered with FAIRDOM-SEEK (including accreditation to relevant people) using a [PUBMED](http://www.ncbi.nlm.nih.gov/pubmed) identifier or [DOI](http://www.doi.org/),

--- a/_pages/rightfield_templates.md
+++ b/_pages/rightfield_templates.md
@@ -2,6 +2,7 @@
 permalink: /rightfield_templates.html
 title: "Semantic spreadsheet templates"
 layout: single
+docs: https://rightfield.org.uk/guide
 ---
 
 

--- a/_pages/simulate_sbml.md
+++ b/_pages/simulate_sbml.md
@@ -2,6 +2,7 @@
 permalink: /simulate_sbml.html
 title: "Simulate SBML, COPASI and Morpheus models"
 layout: single
+docs: https://docs.seek4science.org/help/user-guide/copasi-button
 ---
 
 Most models that conforms to the [SBML](https://sbml.org/) format can be simulated within FAIRDOM-SEEK.

--- a/_pages/yellow_pages.md
+++ b/_pages/yellow_pages.md
@@ -2,6 +2,7 @@
 permalink: /yellow_pages.html
 title: "Who's doing what, where?"
 layout: single
+docs: https://docs.seek4science.org/help/user-guide/administer-project-members
 ---
 
 We recognise that people, and their knowledge, are important.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,8 +13,3 @@
   background-color: #f9f9f9;
   border: 1px solid #bbbbbb;
 }
-
-/* Button to documentation page */
-.btn--docs:hover {
-  background-color: #2c3e50;
-}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,3 +13,8 @@
   background-color: #f9f9f9;
   border: 1px solid #bbbbbb;
 }
+
+/* Button to documentation page */
+.btn--docs:hover {
+  background-color: #2c3e50;
+}


### PR DESCRIPTION
Closes #17 -- add a line to the front-matter on feature pages to link to the most relevant page of the documentation, display as a button at the end of the page content. 

There is already a feature to show `page.link` as a button. I copied this feature, called it `page.docs` and put the button display text as "Link to documentation page". I kept the same styling, except I made the hover colour darker, so it is more contrasting to the default state colour. 

I added the following links.

Feature page | Docs page
---|---
Organise and store you data | User Guide > Experiments > ISA Overview
Explore spreadsheets | User Guide > Assets > Adding assets
Simulate SBML, COPASI and Morpheus models | User Guide > Integrations > Using Copasi
Who’s doing what, where? | User Guide > Yellow Pages > Administer project members
Flexible sharing controls | User Guide > General attributes > Sharing
Semantic spreadsheet templates | RightField Guide (external)
Extended Metadata | Technical Guide > Extended Metadata > Technical Overview
Publishing and DOI | Technical Guide > Administering > Configuring DOI and PubMed search
API and Programmatic Access | User Guide > API Introduction

Should there be a user guide page for semantic spreadsheet templates? Everything I found about JERM and RightField was in the archived section. -- Update, link to https://rightfield.org.uk/guide

Sample screenshots
<img width="1445" height="1080" alt="image" src="https://github.com/user-attachments/assets/33fc423f-d247-4720-a639-483eb94ed1d3" />


<img width="1445" height="1052" alt="image" src="https://github.com/user-attachments/assets/a5eeb137-96e8-47ab-99ad-ee4b910156bb" />

Mobile view: 
<img width="380" height="684" alt="image" src="https://github.com/user-attachments/assets/f2f22104-59be-466b-a6ac-2f2f96225294" />

Hover:
<img width="632" height="257" alt="image" src="https://github.com/user-attachments/assets/bc9980c5-5d04-468b-a3d5-ab38672ca46c" />

